### PR TITLE
Adapted Assessment mapping for Honos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+validator_cli.jar
 CLAUDE.md
 .DS_Store
 Thumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+CLAUDE.md
 .DS_Store
 Thumbs.db
 /fsh-generated

--- a/maps/ObservationSurveyToAssessmentEvent.map
+++ b/maps/ObservationSurveyToAssessmentEvent.map
@@ -36,6 +36,10 @@ group populateAssessmentResult(source obs: Observation, target assessment: Asses
     vcc.extension as ext where $this.url = "https://www.hl7.org/fhir/R4/observation.html#component/valueQuantity" then {
       ext.valueQuantity as vq -> assessment then resultValueQuantityToAssessmentResult(vq, assessment);
     };
+    // valueCodeableConcept/extension/ValueString -> AssessmentResult/hasStringValue
+    vcc.extension as ext where $this.url = "https://www.hl7.org/fhir/R4/observation.html#component/valueString" then {
+      ext.valueString as vs -> result.hasStringValue = vs;
+    };
   } "valueCodeableConcept";
 
   // value[x] as Quantity -> AssessmentResult/hasQuantity
@@ -90,6 +94,10 @@ group assessmentEvent(source observation : Observation, target content : Content
          // valueQuantity extension
          vcc.extension as ext where $this.url = "https://www.hl7.org/fhir/R4/observation.html#component/valueQuantity" then {
            ext.valueQuantity as vq -> component then resultValueQuantityToAssessmentResult(vq, component);
+         };
+         // valueString extension
+         vcc.extension as ext where $this.url = "https://www.hl7.org/fhir/R4/observation.html#component/valueString" then {
+           ext.valueString as vs -> result.hasStringValue = vs;
          };
        } "compValueCodeableConcept";
        

--- a/maps/ObservationSurveyToAssessmentEvent.map
+++ b/maps/ObservationSurveyToAssessmentEvent.map
@@ -37,9 +37,13 @@ group assessmentEvent(source observation : Observation, target content : Content
    // observation.code -> Assessment
    observation.code as observation_code -> assessmentEvent.hasAssessment = create('Assessment') as assessment, assessment.id = uuid() then {
      observation_code.coding as coding -> assessment then codingToCode(coding, assessment);
-     observation_code.coding as coding then {
-       coding.display as d -> assessment.hasName = d;
-     };
+     // hasName: prefer observation_code.text, fallback to coding.display
+     observation_code.text as t -> assessment.hasName = t;
+     observation_code where $this.text.exists().not() then {
+       observation_code.coding as coding then {
+         coding.display as d -> assessment.hasName = d;
+       } "hasNameFromDisplay";
+     } "hasNameFallback";
 
      // valueCodeableConcept -> AssessmentResult/hasCode
      observation.valueCodeableConcept as vcc -> assessment.hasResult = create('AssessmentResult') as result, result.id = uuid() then {
@@ -60,14 +64,13 @@ group assessmentEvent(source observation : Observation, target content : Content
        // coding -> Components/hasCode
        comp.code as srcCode then {
          srcCode.coding as coding -> component then codingToCode(coding, component);
-         srcCode.coding as coding then {
-           coding.display as d -> component.hasName = d;
-         };
-
-         // Handle components without SNOMED code
-         srcCode.coding as srcCoding where $this.system = 'https://www.biomedit.ch/rdf/sphn-schema/sphn#AssessmentComponent' then {
-           srcCoding.display as d -> component.hasName = d;
-         };
+         // hasName: prefer srcCode.text, fallback to coding.display
+         srcCode.text as t -> component.hasName = t;
+         srcCode where $this.text.exists().not() then {
+           srcCode.coding as coding then {
+             coding.display as d -> component.hasName = d;
+           } "componentHasNameFromDisplay";
+         } "componentHasNameFallback";
        };
 
        // Component results

--- a/maps/ObservationSurveyToAssessmentEvent.map
+++ b/maps/ObservationSurveyToAssessmentEvent.map
@@ -25,6 +25,23 @@ group codingToCode(source coding, target trg){
  } "codingToCode";
 }
 
+// Helper to populate Assessment result from observation
+// Note: Uses polymorphic obs.value access since obs.valueQuantity/obs.valueCodeableConcept
+// don't resolve correctly when observation is passed as a group parameter
+group populateAssessmentResult(source obs: Observation, target assessment: Assessment) {
+  // value[x] as CodeableConcept -> AssessmentResult/hasCode
+  obs.value as vcc where $this.is(CodeableConcept) -> assessment.hasResult = create('AssessmentResult') as result, result.id = uuid() then {
+    vcc.coding as coding -> result then codingToCode(coding, result);
+    // valueCodeableConcept/extension/ValueQuantity -> Assessment/hasQuantity
+    vcc.extension as ext where $this.url = "https://www.hl7.org/fhir/R4/observation.html#component/valueQuantity" then {
+      ext.valueQuantity as vq -> assessment then resultValueQuantityToAssessmentResult(vq, assessment);
+    };
+  } "valueCodeableConcept";
+
+  // value[x] as Quantity -> AssessmentResult/hasQuantity
+  obs.value as vq where $this.is(Quantity) -> assessment.hasResult = create('AssessmentResult') as result, result.id = uuid(), result.hasQuantity as q then quantity(vq, q) "valueQuantity";
+}
+
 // Main mapping Observation -> AssessmentEvent
 group assessmentEvent(source observation : Observation, target content : Content) <<types>> {
  observation -> content.AssessmentEvent = create('AssessmentEvent') as assessmentEvent then {
@@ -45,19 +62,8 @@ group assessmentEvent(source observation : Observation, target content : Content
        } "hasNameFromDisplay";
      } "hasNameFallback";
 
-     // valueCodeableConcept -> AssessmentResult/hasCode
-     observation.valueCodeableConcept as vcc -> assessment.hasResult = create('AssessmentResult') as result, result.id = uuid() then {
-       vcc.coding as coding -> result then codingToCode(coding, result);
-
-       // valueCodeableConcept/extension/ValueQuantity  -> Assessment/hasQuantity
-       // present if result is available as code and value
-       vcc.extension as ext where $this.url = "https://www.hl7.org/fhir/R4/observation.html#component/valueQuantity" then {
-         ext.valueQuantity as vq -> assessment then resultValueQuantityToAssessmentResult(vq, assessment);
-       };
-     } "valueCodeableConcept";
-
-     // valueQuantity -> AssessmentResult/hasQuantity
-     observation.valueQuantity as vq -> assessment then resultValueQuantityToAssessmentResult(vq, assessment);
+     // Populate assessment result (valueCodeableConcept or valueQuantity)
+     observation -> assessment then populateAssessmentResult(observation, assessment) "assessmentResult";
  
      // Component -> Assessment/Component
      observation.component as comp -> assessment.hasComponent = create('AssessmentComponent') as component, component.id = uuid() then {

--- a/maps/ObservationSurveyToAssessmentEvent.map
+++ b/maps/ObservationSurveyToAssessmentEvent.map
@@ -40,6 +40,9 @@ group populateAssessmentResult(source obs: Observation, target assessment: Asses
 
   // value[x] as Quantity -> AssessmentResult/hasQuantity
   obs.value as vq where $this.is(Quantity) -> assessment.hasResult = create('AssessmentResult') as result, result.id = uuid(), result.hasQuantity as q then quantity(vq, q) "valueQuantity";
+
+  // value[x] as String -> AssessmentResult/hasStringValue
+  obs.value as vs where $this.is(string) -> assessment.hasResult = create('AssessmentResult') as result, result.id = uuid(), result.hasStringValue = vs "valueString";
 }
 
 // Main mapping Observation -> AssessmentEvent
@@ -92,6 +95,9 @@ group assessmentEvent(source observation : Observation, target content : Content
        
        // Standalone valueQuantity
        comp.valueQuantity as vq -> component then resultValueQuantityToAssessmentResult(vq, component);
+
+       // Standalone valueString
+       comp.valueString as vs -> component.hasResult = create('AssessmentResult') as result, result.id = uuid(), result.hasStringValue = vs "compValueString";
 
      } "AssessmentComponent";
    } "Assessment";

--- a/maps/ObservationSurveyToAssessmentEvent.map
+++ b/maps/ObservationSurveyToAssessmentEvent.map
@@ -13,12 +13,12 @@ uses "http://research.balgrist.ch/fhir2sphn/StructureDefinition/AssessmentEvent"
 
 imports "http://research.balgrist.ch/fhir2sphn/StructureMap/Utils"
 
-// Utils
-group resultValueQuantityToAssessmentResult(source vq: Quantity, target assessment: Assessment){
+// Helper groups
+group resultValueQuantityToAssessmentResult(source vq: Quantity, target assessment: Assessment) {
  vq -> assessment.hasResult = create('AssessmentResult') as result, result.id = uuid(), result.hasQuantity as q then quantity(vq, q) "AssessmentResult";
 }
 
-group codingToCode(source coding, target trg){
+group codingToCode(source coding, target trg) {
  coding as srcCoding where $this.system = 'http://snomed.info/sct' -> trg.hasCode as trgCode then {
    srcCoding.code as c -> trgCode.termid = c as termid,
    trgCode.iri = append('http://snomed.info/id/', termid);
@@ -69,9 +69,9 @@ group assessmentEvent(source observation : Observation, target content : Content
        } "hasNameFromDisplay";
      } "hasNameFallback";
 
-     // Populate assessment result (valueCodeableConcept or valueQuantity)
+     // Populate assessment result (valueCodeableConcept, valueQuantity, or valueString)
      observation -> assessment then populateAssessmentResult(observation, assessment) "assessmentResult";
- 
+
      // Component -> Assessment/Component
      observation.component as comp -> assessment.hasComponent = create('AssessmentComponent') as component, component.id = uuid() then {
        // coding -> Components/hasCode
@@ -86,11 +86,10 @@ group assessmentEvent(source observation : Observation, target content : Content
          } "componentHasNameFallback";
        };
 
-       // Component results
-       //  valueCodeableConcept
+       // Component results: valueCodeableConcept
        comp.valueCodeableConcept as vcc -> component.hasResult = create('AssessmentResult') as result, result.id = uuid() then {
          vcc.coding as coding -> result then codingToCode(coding, result);
-       
+
          // valueQuantity extension
          vcc.extension as ext where $this.url = "https://www.hl7.org/fhir/R4/observation.html#component/valueQuantity" then {
            ext.valueQuantity as vq -> component then resultValueQuantityToAssessmentResult(vq, component);
@@ -100,7 +99,7 @@ group assessmentEvent(source observation : Observation, target content : Content
            ext.valueString as vs -> result.hasStringValue = vs;
          };
        } "compValueCodeableConcept";
-       
+
        // Standalone valueQuantity
        comp.valueQuantity as vq -> component then resultValueQuantityToAssessmentResult(vq, component);
 


### PR DESCRIPTION
  Bug Fix: assessment.hasResult not generated for standalone valueQuantity                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                  
  Root cause: In FML, when an Observation is passed as a parameter to a group, accessing polymorphic properties with specific type names (obs.valueQuantity, obs.valueCodeableConcept) doesn't work.                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                  
  Solution: New helper group populateAssessmentResult that uses polymorphic access with type checking:                                                                                                                                                                                                                                                            
  - obs.value as vq where $this.is(Quantity) instead of obs.valueQuantity                                                                                                                                                                                                                                                                                         
  - obs.value as vcc where $this.is(CodeableConcept) instead of obs.valueCodeableConcept                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                  
  New Features                                                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                  
  1. valueString support - Added handling for string values:                                                                                                                                                                                                                                                                                                      
    - Assessment level: standalone valueString → hasStringValue                                                                                                                                                                                                                                                                                                   
    - Component level: standalone valueString → hasStringValue                                                                                                                                                                                                                                                                                                    
    - Extension valueString (alongside valueCodeableConcept) → hasStringValue                                                                                                                                                                                                                                                                                     
  2. Improved hasName handling - Now prefers code.text over coding.display:                                                                                                                                                                                                                                                                                       
    - observation_code.text takes priority                                                                                                                                                                                                                                                                                                                        
    - Falls back to coding.display only if text doesn't exist          