### PR TITLE
Fix assessment effective mapping

### DIFF
--- a/maps/ObservationSurveyToAssessmentEvent.map
+++ b/maps/ObservationSurveyToAssessmentEvent.map
@@ -56,7 +56,7 @@ group assessmentEvent(source observation : Observation, target content : Content
    observation.meta as m then refSourceSystem(m, assessmentEvent);
    observation.id as id -> assessmentEvent.id = ('AssessmentEvent/' & %id);
    // Use generic 'effective' instead of 'effectiveDateTime'
-   // workaround: observation.effectiveDateTime fails when value[x] is Quantity
+   // workaround: observation.effectiveDateTime fails sometimes (unclear when; works for many assessment types, but not honos)
    observation.effective as t where $this.is(dateTime) -> assessmentEvent.hasDateTime = t;
    observation.encounter as encounter -> assessmentEvent.hasAdministrativeCase = encounter;
 

--- a/maps/ObservationSurveyToAssessmentEvent.map
+++ b/maps/ObservationSurveyToAssessmentEvent.map
@@ -55,7 +55,9 @@ group assessmentEvent(source observation : Observation, target content : Content
    // Metadata and basic fields
    observation.meta as m then refSourceSystem(m, assessmentEvent);
    observation.id as id -> assessmentEvent.id = ('AssessmentEvent/' & %id);
-   observation.effectiveDateTime as t -> assessmentEvent.hasDateTime = t;
+   // Use generic 'effective' instead of 'effectiveDateTime'
+   // workaround: observation.effectiveDateTime fails when value[x] is Quantity
+   observation.effective as t where $this.is(dateTime) -> assessmentEvent.hasDateTime = t;
    observation.encounter as encounter -> assessmentEvent.hasAdministrativeCase = encounter;
 
    // observation.code -> Assessment


### PR DESCRIPTION
 `observation.effectiveDateTime as t -> assessmentEvent.hasDateTime = t;`
in some cases failed to create the `assessmentEvent.hasDateTime ` object.
(unclear when; works for many assessment types, but not honos)

Use generic 'effective' instead of 'effectiveDateTime' to fix