### PR TITLE
Replace concatenated choice type references

### DIFF
--- a/maps/ClaimToBilledDiagnosisProcedure.map
+++ b/maps/ClaimToBilledDiagnosisProcedure.map
@@ -21,14 +21,14 @@ group claimBilled(source claim : Claim, target content: Content) <<types>> {
 
     // Claim.extension[encounter-id] -> hasAdministrativeCase
     claim.extension as ext where $this.url = 'http://research.balgrist.ch/fhir/StructureDefinition/encounter-id' then {
-      ext.valueReference as encounter -> diag.hasAdministrativeCase = encounter;
+      ext.value : Reference as encounter -> diag.hasAdministrativeCase = encounter;
     };
 
     // Claim.created -> hasRecordDateTime
     claim.created as created -> diag.hasRecordDateTime = created;
 
     // diagnosisCodeableConcept -> hasCode
-    diagnosis.diagnosisCodeableConcept as code then {
+    diagnosis.diagnosis : CodeableConcept as code then {
       code.coding as coding where $this.system = 'http://hl7.org/fhir/sid/icd-10' -> diag.hasCode as tgtCode then {
         coding.code as c -> tgtCode.termid = c, tgtCode.iri = ('https://biomedit.ch/rdf/sphn-resource/icd-10-gm/' & c) "i";
       };
@@ -49,14 +49,14 @@ group claimBilled(source claim : Claim, target content: Content) <<types>> {
 
     // Claim.extension[encounter-id] -> hasAdministrativeCase
     claim.extension as ext where $this.url = 'http://research.balgrist.ch/fhir/StructureDefinition/encounter-id' then {
-      ext.valueReference as encounter -> proc.hasAdministrativeCase = encounter;
+      ext.value : Reference as encounter -> proc.hasAdministrativeCase = encounter;
     };
 
     // Claim.created -> hasStartDateTime
     claim.created as created -> proc.hasStartDateTime = created;
 
     // procedureCodeableConcept -> hasCode
-    procedure.procedureCodeableConcept as code then {
+    procedure.procedure : CodeableConcept as code then {
       code.coding as coding -> proc.hasCode as tgtCode then {
         coding.code as c -> tgtCode.termid = c, tgtCode.iri = ('https://biomedit.ch/rdf/sphn-resource/chop/' & c) "i";
       };

--- a/maps/ConditionToNursingDiagnosis.map
+++ b/maps/ConditionToNursingDiagnosis.map
@@ -26,7 +26,7 @@ group nursingDiagnosis(source condition : Condition, target content: Content) <<
     };
 
     // onsetAge -> Content.Age
-    condition.onsetAge as onsetAge -> content.Age = create('Age') as age then {
+    condition.onset : Age as onsetAge -> content.Age = create('Age') as age then {
       condition.meta as m then refSourceSystem(m, age);
       onsetAge -> age.id = uuid() as id,
         diagnosis.hasSubjectAge = create('Reference') as ref, ref.reference = id,

--- a/maps/EncounterToAdministrativeCase.map
+++ b/maps/EncounterToAdministrativeCase.map
@@ -93,7 +93,7 @@ group adminCase(source encounter : Encounter, target content: Content) <<types>>
         encounter.hospitalization as hospitalization then {
           // extension [dischargedestination] -> hasDischargeLocation
           hospitalization.extension as ext where $this.url = 'http://fhir.ch/ig/ch-core/StructureDefinition/ch-ext-bfs-ms-dischargedestination' -> discharge.hasTargetLocation = create('Location') as location then {
-            ext.valueCoding as coding then {
+            ext.value : Coding as coding then {
               coding.code as code -> location.id = uuid(), translate(code, '#cm-encounter-dischargedestination') as cm,
                 location.hasTypeCode as typeCode, typeCode.termid = (%cm.code), typeCode.iri = (%cm.system & '/' & %cm.code) "dischargedestination";
             };

--- a/maps/MedicationAdministrationToDrugAdministrationEvent.map
+++ b/maps/MedicationAdministrationToDrugAdministrationEvent.map
@@ -25,8 +25,8 @@ group medication_administration(source medicationAdministration : MedicationAdmi
         medicationAdministration.context as context -> event.hasAdministrativeCase = context;
 
         // Start/end dates
-        medicationAdministration.effectiveDateTime as dateTime -> event.hasStartDateTime = dateTime;
-        medicationAdministration.effectivePeriod as period then {
+        medicationAdministration.effective : dateTime as dateTime -> event.hasStartDateTime = dateTime;
+        medicationAdministration.effective : Period as period then {
             period.start as start -> event.hasStartDateTime = start;
             period.end as end -> event.hasEndDateTime = end;
         };
@@ -43,7 +43,7 @@ group medication_administration(source medicationAdministration : MedicationAdmi
                     ingredient -> substance.id = uuid() "substance_id";
 
                     // Medication/ingredient/coding -> Drug/hasActiveIngredient/code
-                    ingredient.itemCodeableConcept as code then {
+                    ingredient.item : CodeableConcept as code then {
                         code.coding first as coding where $this.system = "http://www.cas.org" -> substance.hasCode as substanceCode then {
                             coding.code as c -> substanceCode.id = uuid(), substanceCode.hasIdentifier = c;
                             coding.system as s -> substanceCode.hasCodingSystemAndVersion = s;
@@ -60,7 +60,7 @@ group medication_administration(source medicationAdministration : MedicationAdmi
                     // Medication/ingredient/strength/extension/sphn#Substance_hasQuantity -> Drug/hasActiveIngredient/hasQuantity
                     ingredient.strength as strength then {
                         strength.extension first as e where $this.url = "https://www.biomedit.ch/rdf/sphn-schema/sphn#Substance_hasQuantity" then {
-                            e.valueQuantity as value -> substance.hasQuantity as q then quantity(value, q);
+                            e.value : Quantity as value -> substance.hasQuantity as q then quantity(value, q);
                         } "valueQuantity";
                     };
                 } "Substance";

--- a/maps/ObservationSurveyToAssessmentEvent.map
+++ b/maps/ObservationSurveyToAssessmentEvent.map
@@ -34,11 +34,11 @@ group populateAssessmentResult(source obs: Observation, target assessment: Asses
     vcc.coding as coding -> result then codingToCode(coding, result);
     // valueCodeableConcept/extension/ValueQuantity -> Assessment/hasQuantity
     vcc.extension as ext where $this.url = "https://www.hl7.org/fhir/R4/observation.html#component/valueQuantity" then {
-      ext.valueQuantity as vq -> assessment then resultValueQuantityToAssessmentResult(vq, assessment);
+      ext.value : Quantity as vq -> assessment then resultValueQuantityToAssessmentResult(vq, assessment);
     };
     // valueCodeableConcept/extension/ValueString -> AssessmentResult/hasStringValue
     vcc.extension as ext where $this.url = "https://www.hl7.org/fhir/R4/observation.html#component/valueString" then {
-      ext.valueString as vs -> result.hasStringValue = vs;
+      ext.value : string as vs -> result.hasStringValue = vs;
     };
   } "valueCodeableConcept";
 
@@ -89,24 +89,24 @@ group assessmentEvent(source observation : Observation, target content : Content
        };
 
        // Component results: valueCodeableConcept
-       comp.valueCodeableConcept as vcc -> component.hasResult = create('AssessmentResult') as result, result.id = uuid() then {
+       comp.value : CodeableConcept as vcc -> component.hasResult = create('AssessmentResult') as result, result.id = uuid() then {
          vcc.coding as coding -> result then codingToCode(coding, result);
 
          // valueQuantity extension
          vcc.extension as ext where $this.url = "https://www.hl7.org/fhir/R4/observation.html#component/valueQuantity" then {
-           ext.valueQuantity as vq -> component then resultValueQuantityToAssessmentResult(vq, component);
+           ext.value : Quantity as vq -> component then resultValueQuantityToAssessmentResult(vq, component);
          };
          // valueString extension
          vcc.extension as ext where $this.url = "https://www.hl7.org/fhir/R4/observation.html#component/valueString" then {
-           ext.valueString as vs -> result.hasStringValue = vs;
+           ext.value : string as vs -> result.hasStringValue = vs;
          };
        } "compValueCodeableConcept";
 
        // Standalone valueQuantity
-       comp.valueQuantity as vq -> component then resultValueQuantityToAssessmentResult(vq, component);
+       comp.value : Quantity as vq -> component then resultValueQuantityToAssessmentResult(vq, component);
 
        // Standalone valueString
-       comp.valueString as vs -> component.hasResult = create('AssessmentResult') as result, result.id = uuid(), result.hasStringValue = vs "compValueString";
+       comp.value : string as vs -> component.hasResult = create('AssessmentResult') as result, result.id = uuid(), result.hasStringValue = vs "compValueString";
 
      } "AssessmentComponent";
    } "Assessment";

--- a/maps/ObservationVitalSignToMeasurement.map
+++ b/maps/ObservationVitalSignToMeasurement.map
@@ -43,7 +43,7 @@ group measurementParent(source observation : Observation, target measurement: Me
   observation.meta as m then refSourceSystem(m, measurement);
   observation.id as id  -> measurement.id = ('Observation/' & %id);
   observation.encounter as encounter -> measurement.hasAdministrativeCase = encounter;
-  observation.effectiveDateTime as effectiveDateTime -> measurement.hasStartDateTime = effectiveDateTime;
+  observation.effective : dateTime as effectiveDateTime -> measurement.hasStartDateTime = effectiveDateTime;
 
   // method (Snomed CT) -> hasMethodCode
   observation.method as method then {
@@ -80,7 +80,7 @@ group measurementOneResult(source observation : Observation, target measurement:
   observation.meta as m then refSourceSystem(m, measurement);
   observation.id as id  -> measurement.id = ('Observation/' & %id);
   observation.encounter as encounter -> measurement.hasAdministrativeCase = encounter;
-  observation.effectiveDateTime as effectiveDateTime -> measurement.hasStartDateTime = effectiveDateTime;
+  observation.effective : dateTime as effectiveDateTime -> measurement.hasStartDateTime = effectiveDateTime;
 
   // method (Snomed CT) -> hasMethodCode
   observation.method as method then {


### PR DESCRIPTION
e.g., `effectiveDateTime` with the parent + colon notation (e.g., `effective : dateTime`)