### PR TITLE
update deprecated snomed code 285201006 | Hospital environment (envir…

### DIFF
--- a/maps/EncounterToAdministrativeCase.map
+++ b/maps/EncounterToAdministrativeCase.map
@@ -5,7 +5,7 @@ conceptmap "cm-encounter-admitSource" {
   prefix t = "http://snomed.info/id"
   s:1 == t:264362003        // Zuhause
   s:2 == t:264362003        // Zuhause mit SPITEX Versorgung
-  s:3 == t:285201006        // Krankenheim, Pflegeheim
+  s:3 == t:42665001         // Krankenheim, Pflegeheim
   s:4 == t:257652008        // Altersheim, andere sozialmed. Institutionen
   s:5 == t:702914003        // Psychiatrische Klinik, anderer Betrieb
   s:55 == t:702914003       // Psychiatrische Abteilung/Klinik, gleicher Betrieb
@@ -22,7 +22,7 @@ conceptmap "cm-encounter-dischargedestination" {
   prefix s = "http://fhir.ch/ig/ch-core/ValueSet/bfs-medstats-28-dischargedestination"
   prefix t = "http://snomed.info/id"
   s:1 == t:264362003        // Zuhause
-  s:2 == t:285201006        // Krankenheim, Pflegeheim
+  s:2 == t:42665001         // Krankenheim, Pflegeheim
   s:3 == t:257652008        // Altersheim, andere sozialmed. Institution
   s:4 == t:702914003        // Psychiatrische Klinik, anderer Betrieb
   s:44 == t:702914003       // Psychiatrische Abteilung/Klinik, gleicher Betrieb

--- a/tests/maps/test_encounter_to_administrative_case.py
+++ b/tests/maps/test_encounter_to_administrative_case.py
@@ -128,7 +128,7 @@ class TestAdmission:
         )
 
     def test_admit_source_3_maps_nursing_home(self, transform_bundle, make_bundle, base_patient):
-        """admitSource code 3 (Pflegeheim) maps to SNOMED 285201006."""
+        """admitSource code 3 (Pflegeheim) maps to SNOMED 42665001."""
         encounter = make_encounter(start="2024-01-15T08:00:00Z", admit_source="3")
         bundle = make_bundle(base_patient, encounter)
 
@@ -137,8 +137,8 @@ class TestAdmission:
         assert_code_mapped(
             result,
             "content.AdministrativeCase[0].hasAdmission.hasOriginLocation.hasTypeCode",
-            "285201006",
-            "/285201006",
+            "42665001",
+            "/42665001",
         )
 
     def test_admit_source_5_maps_psychiatric(self, transform_bundle, make_bundle, base_patient):
@@ -218,7 +218,7 @@ class TestDischarge:
     def test_discharge_destination_2_maps_nursing_home(
         self, transform_bundle, make_bundle, base_patient
     ):
-        """dischargeDestination code 2 (Pflegeheim) maps to SNOMED 285201006."""
+        """dischargeDestination code 2 (Pflegeheim) maps to SNOMED 42665001."""
         encounter = make_encounter(
             start="2024-01-15T08:00:00Z",
             end="2024-01-20T14:00:00Z",
@@ -231,8 +231,8 @@ class TestDischarge:
         assert_code_mapped(
             result,
             "content.AdministrativeCase[0].hasDischarge.hasTargetLocation.hasTypeCode",
-            "285201006",
-            "/285201006",
+            "42665001",
+            "/42665001",
         )
 
     def test_discharge_destination_5_maps_rehab(self, transform_bundle, make_bundle, base_patient):


### PR DESCRIPTION
The snomed code `285201006 | Hospital environment (environment) |` is deprecated.

Since the source values are `Krankenheim, Pflegeheim`, instead of replacing it with the current `22232009 | Hospital (environment) |`, replace it with the semantically better fitting `42665001 | Nursing home (environment) |`